### PR TITLE
chore: update go modules and make e2e tests offline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
-go.sum

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -1,9 +1,11 @@
 package socks5proxy
 
 import (
+	"io"
 	"log"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"sync"
 	"testing"
@@ -55,6 +57,12 @@ func TestHTTPConnect(t *testing.T) {
 
 	time.Sleep(1 * time.Second)
 
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer target.Close()
+
 	ProxyURI, err := url.ParseRequestURI("http://127.0.0.1:18290")
 	if err != nil {
 		log.Panic(err)
@@ -68,7 +76,7 @@ func TestHTTPConnect(t *testing.T) {
 	}
 	// http.ListenAndServe
 
-	req, err := http.NewRequest("GET", "http://www.baidu.com/", nil)
+	req, err := http.NewRequest("GET", target.URL, nil)
 	if err != nil {
 		log.Panic(err)
 	}
@@ -77,10 +85,10 @@ func TestHTTPConnect(t *testing.T) {
 		log.Panic(err)
 	}
 	assert.Equal(t, resp.StatusCode, 200)
-	var respbody []byte
-	n, err := resp.Body.Read(respbody)
+	defer resp.Body.Close()
+	respbody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Panic(err)
 	}
-	log.Print(string(respbody[:n]))
+	log.Print(string(respbody))
 }

--- a/go.mod
+++ b/go.mod
@@ -1,15 +1,11 @@
 module github.com/shikanon/socks5proxy
 
-go 1.12
+go 1.22
+
+require github.com/stretchr/testify v1.4.0
 
 require (
-	github.com/golang/mock v1.3.1
-	github.com/stretchr/testify v1.4.0
-	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 // indirect
-	golang.org/x/net v0.0.0-20191021144547-ec77196f6094 // indirect
-	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
-	golang.org/x/sys v0.0.0-20191025021431-6c3a3bfe00ae // indirect
-	golang.org/x/text v0.3.2 // indirect
-	golang.org/x/tools v0.0.0-20191025023517-2077df36852e // indirect
-	golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 // indirect
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v2 v2.2.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
Closes #24
Closes #26

- Stop ignoring go.sum and generate go.sum via go mod tidy
- Bump go directive to 1.22
- Make TestHTTPConnect use a local httptest server (offline & stable)