### PR TITLE
fix: include password bytes in cipher derivation (#18)

### DIFF
--- a/cryptogram.go
+++ b/cryptogram.go
@@ -78,7 +78,7 @@ func CreateSimpleCipher(passwd string) (*DefaultAuth, error) {
 	if len(passwd) == 0 {
 		return nil, errors.New("密码不能为空")
 	}
-	for v := range passwd {
+	for _, v := range []byte(passwd) {
 		sumint += int(v)
 	}
 	sumint = sumint % 256
@@ -102,7 +102,7 @@ func CreateRandomCipher(passwd string) (*DefaultAuth, error) {
 	if len(passwd) == 0 {
 		return nil, errors.New("密码不能为空")
 	}
-	for v := range passwd {
+	for _, v := range []byte(passwd) {
 		sumint += int(v)
 	}
 	var encodeString [256]byte

--- a/cryptogram_test.go
+++ b/cryptogram_test.go
@@ -49,3 +49,25 @@ func TestRandomCipher(t *testing.T) {
 	}
 	assert.Equal(t, b, c)
 }
+
+func TestCipherDerivationUsesPasswordContent(t *testing.T) {
+	simpleA, err := CreateSimpleCipher("aaaaaa")
+	if err != nil {
+		log.Panic(err)
+	}
+	simpleB, err := CreateSimpleCipher("bbbbbb")
+	if err != nil {
+		log.Panic(err)
+	}
+	randomA, err := CreateRandomCipher("aaaaaa")
+	if err != nil {
+		log.Panic(err)
+	}
+	randomB, err := CreateRandomCipher("bbbbbb")
+	if err != nil {
+		log.Panic(err)
+	}
+
+	assert.NotEqual(t, simpleA.Encode, simpleB.Encode)
+	assert.NotEqual(t, randomA.Encode, randomB.Encode)
+}


### PR DESCRIPTION
## Summary
- fix simple/random cipher derivation to use password bytes instead of rune indexes
- add a regression test proving same-length passwords derive different tables

## Verification
- `CGO_ENABLED=0 go test -run 'Test(SampleCipher|RandomCipher|CipherDerivationUsesPasswordContent)$' .`
- `go test ./...` currently hits a local macOS `dyld: missing LC_UUID load command` runtime issue unrelated to this patch

Closes #18