### PR TITLE
fix: secure only valid buffer bytes in SecureCopy (#19)

### DIFF
--- a/cryptogram.go
+++ b/cryptogram.go
@@ -149,8 +149,11 @@ func SecureCopy(src io.ReadWriteCloser, dst io.ReadWriteCloser, secure func(b []
 	buf := make([]byte, size)
 	for {
 		nr, er := src.Read(buf)
-		secure(buf)
 		if nr > 0 {
+			if secureErr := secure(buf[:nr]); secureErr != nil {
+				err = secureErr
+				break
+			}
 			nw, ew := dst.Write(buf[0:nr])
 			if nw > 0 {
 				written += int64(nw)

--- a/cryptogram_test.go
+++ b/cryptogram_test.go
@@ -1,10 +1,20 @@
 package socks5proxy
 
 import (
+	"bytes"
+	"errors"
 	"github.com/stretchr/testify/assert"
 	"log"
 	"testing"
 )
+
+type bufferReadWriteCloser struct {
+	*bytes.Buffer
+}
+
+func (b *bufferReadWriteCloser) Close() error {
+	return nil
+}
 
 func TestSampleCipher(t *testing.T) {
 	auth, err := CreateSimpleCipher("abc")
@@ -70,4 +80,37 @@ func TestCipherDerivationUsesPasswordContent(t *testing.T) {
 
 	assert.NotEqual(t, simpleA.Encode, simpleB.Encode)
 	assert.NotEqual(t, randomA.Encode, randomB.Encode)
+}
+
+func TestSecureCopyOnlySecuresValidBytes(t *testing.T) {
+	src := &bufferReadWriteCloser{Buffer: bytes.NewBufferString("abc")}
+	dst := &bufferReadWriteCloser{Buffer: bytes.NewBuffer(nil)}
+	var securedLen int
+
+	written, err := SecureCopy(src, dst, func(b []byte) error {
+		securedLen = len(b)
+		for i := range b {
+			b[i] = b[i] + 1
+		}
+		return nil
+	})
+
+	assert.NoError(t, err)
+	assert.EqualValues(t, 3, written)
+	assert.Equal(t, 3, securedLen)
+	assert.Equal(t, "bcd", dst.String())
+}
+
+func TestSecureCopyReturnsSecureError(t *testing.T) {
+	src := &bufferReadWriteCloser{Buffer: bytes.NewBufferString("abc")}
+	dst := &bufferReadWriteCloser{Buffer: bytes.NewBuffer(nil)}
+	expectedErr := errors.New("secure failed")
+
+	written, err := SecureCopy(src, dst, func(b []byte) error {
+		return expectedErr
+	})
+
+	assert.Equal(t, expectedErr, err)
+	assert.Zero(t, written)
+	assert.Equal(t, "", dst.String())
 }


### PR DESCRIPTION
## Summary
- run the secure function only on the bytes actually read from the source
- stop copying and return the secure error instead of silently ignoring it
- add regression tests for valid-slice handling and secure error propagation

## Verification
- `CGO_ENABLED=0 go test -run 'Test(SampleCipher|RandomCipher|CipherDerivationUsesPasswordContent|SecureCopyOnlySecuresValidBytes|SecureCopyReturnsSecureError)$' .`

Closes #19