### PR TITLE
refactor: return errors instead of fatal exits (#20)

### DIFF
--- a/client.go
+++ b/client.go
@@ -3,6 +3,7 @@ package socks5proxy
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"log"
 	"net"
 	"net/url"
@@ -16,14 +17,12 @@ type TcpClient struct {
 	server *net.TCPAddr
 }
 
-func handleProxyRequest(localClient *net.TCPConn, serverAddr *net.TCPAddr, auth socks5Auth, recvHTTPProto string) {
+func handleProxyRequest(localClient *net.TCPConn, serverAddr *net.TCPAddr, auth socks5Auth, recvHTTPProto string) error {
 
 	// 远程连接IO
 	dstServer, err := net.DialTCP("tcp", nil, serverAddr)
 	if err != nil {
-		log.Print("远程服务器地址连接错误!!!")
-		log.Print(err)
-		return
+		return err
 	}
 	defer dstServer.Close()
 
@@ -40,18 +39,15 @@ func handleProxyRequest(localClient *net.TCPConn, serverAddr *net.TCPAddr, auth 
 		resp := make([]byte, 1024)
 		n, err := auth.DecodeRead(dstServer, resp)
 		if err != nil {
-			log.Fatal(err)
-			return
+			return err
 		}
 		if n == 0 {
-			log.Fatal("协议错误,服务器返回为空")
-			return
+			return errors.New("协议错误,服务器返回为空")
 		}
 		if resp[1] == 0x00 && n == 2 {
 			log.Print("success")
 		} else {
-			log.Fatal("协议错误，连接失败")
-			return
+			return errors.New("协议错误，连接失败")
 		}
 		// 第二阶段根据认证方式执行对应的认证，由于采用无密码格式，这里省略验证
 		// 第三阶段请求信息
@@ -59,8 +55,7 @@ func handleProxyRequest(localClient *net.TCPConn, serverAddr *net.TCPAddr, auth 
 		buff := make([]byte, 1024)
 		n, err = localClient.Read(buff)
 		if err != nil {
-			log.Print(err)
-			return
+			return err
 		}
 		localReq := buff[:n]
 		j := 0
@@ -78,8 +73,7 @@ func handleProxyRequest(localClient *net.TCPConn, serverAddr *net.TCPAddr, auth 
 
 		dstURI, err := url.ParseRequestURI(httpreq[1])
 		if err != nil {
-			log.Print(err)
-			return
+			return err
 		}
 		var dstAddr string
 		var dstPort = "80"
@@ -90,8 +84,7 @@ func handleProxyRequest(localClient *net.TCPConn, serverAddr *net.TCPAddr, auth 
 			dstAddr = dstAddrPort[0]
 			dstPort = dstAddrPort[1]
 		} else {
-			log.Print("URL parse error!")
-			return
+			return errors.New("URL parse error")
 		}
 
 		resp = []byte{0x05, 0x01, 0x00, 0x03}
@@ -107,36 +100,37 @@ func handleProxyRequest(localClient *net.TCPConn, serverAddr *net.TCPAddr, auth 
 		dstPortBuff := bytes.NewBuffer(make([]byte, 0))
 		dstPortInt, err := strconv.ParseUint(dstPort, 10, 16)
 		if err != nil {
-			log.Fatal(err)
-			return
+			return err
 		}
 		binary.Write(dstPortBuff, binary.BigEndian, dstPortInt)
 		dstPortBytes := dstPortBuff.Bytes() // int为8字节
 		resp = append(resp, dstPortBytes[len(dstPortBytes)-2:]...)
 		n, err = auth.EncodeWrite(dstServer, resp)
 		if err != nil {
-			log.Print(dstServer.RemoteAddr(), err)
-			return
+			return err
 		}
 		n, err = auth.DecodeRead(dstServer, resp)
 		if err != nil {
-			log.Print(dstServer.RemoteAddr(), err)
-			return
+			return err
 		}
 		var targetResp [10]byte
 		copy(targetResp[:10], resp[:n])
 		specialResp := [10]byte{0x05, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
 		if targetResp != specialResp {
-			log.Print("协议错误, 第二次协商返回出错")
-			return
+			return errors.New("协议错误, 第二次协商返回出错")
 		}
 		log.Print("认证成功")
 
 		// 转发消息
 		go func() {
 			defer wg.Done()
-			auth.Encrypt(localReq)
-			dstServer.Write(localReq)
+			if err := auth.Encrypt(localReq); err != nil {
+				log.Print(err)
+				return
+			}
+			if _, err := dstServer.Write(localReq); err != nil {
+				log.Print(err)
+			}
 			// SecureCopy(localClient, dstServer, auth.Encrypt)
 		}()
 
@@ -146,9 +140,7 @@ func handleProxyRequest(localClient *net.TCPConn, serverAddr *net.TCPAddr, auth 
 		}()
 
 		wg.Wait()
-
 	} else {
-
 		// 本地的内容copy到远程端
 		go func() {
 			defer wg.Done()
@@ -163,38 +155,44 @@ func handleProxyRequest(localClient *net.TCPConn, serverAddr *net.TCPAddr, auth 
 		wg.Wait()
 	}
 
+	return nil
 }
 
-func Client(listenAddrString string, serverAddrString string, encrytype string, passwd string, recvHTTPProto string) {
+func Client(listenAddrString string, serverAddrString string, encrytype string, passwd string, recvHTTPProto string) error {
 	//所有客户服务端的流都加密,
 	auth, err := CreateAuth(encrytype, passwd)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	// proxy地址
 	serverAddr, err := net.ResolveTCPAddr("tcp", serverAddrString)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 	log.Printf("连接远程服务器: %s ....", serverAddrString)
 
 	listenAddr, err := net.ResolveTCPAddr("tcp", listenAddrString)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 	log.Printf("监听本地端口: %s ", listenAddrString)
 
 	listener, err := net.ListenTCP("tcp", listenAddr)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	for {
 		localClient, err := listener.AcceptTCP()
 		if err != nil {
-			log.Fatal(err)
+			log.Print(err)
+			continue
 		}
-		go handleProxyRequest(localClient, serverAddr, auth, recvHTTPProto)
+		go func(clientConn *net.TCPConn) {
+			if err := handleProxyRequest(clientConn, serverAddr, auth, recvHTTPProto); err != nil {
+				log.Print(err)
+			}
+		}(localClient)
 	}
 }

--- a/client_server_test.go
+++ b/client_server_test.go
@@ -1,0 +1,15 @@
+package socks5proxy
+
+import "testing"
+
+func TestClientReturnsErrorOnInvalidServerAddress(t *testing.T) {
+	if err := Client("127.0.0.1:0", "bad-addr", "random", "passwd", "http"); err == nil {
+		t.Fatal("expected client startup error")
+	}
+}
+
+func TestServerReturnsErrorOnInvalidListenAddress(t *testing.T) {
+	if err := Server("bad-addr", "random", "passwd"); err == nil {
+		t.Fatal("expected server startup error")
+	}
+}

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -22,5 +22,7 @@ func main() {
 	}
 	log.Println("客户端正在启动...")
 	log.Println(&recvHTTPProto)
-	socks5proxy.Client(*listenAddr, *serverAddr, *encrytype, *passwd, *recvHTTPProto)
+	if err := socks5proxy.Client(*listenAddr, *serverAddr, *encrytype, *passwd, *recvHTTPProto); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -15,5 +15,7 @@ func main() {
 		log.Fatal("请通过 -passwd 设置一个强密码（不能为空）")
 	}
 	log.Println("服务器正在启动...")
-	socks5proxy.Server(*listenAddr, *encrytype, *passwd)
+	if err := socks5proxy.Server(*listenAddr, *encrytype, *passwd); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -23,7 +23,7 @@ func TestConncet(t *testing.T) {
 	// 连接
 	conn, err := net.Dial("tcp", "127.0.0.1:18190")
 	if err != nil {
-		log.Fatalln(err)
+		t.Fatal(err)
 	}
 	defer conn.Close()
 

--- a/server.go
+++ b/server.go
@@ -6,9 +6,9 @@ import (
 	"sync"
 )
 
-func handleClientRequest(client *net.TCPConn, auth socks5Auth) {
+func handleClientRequest(client *net.TCPConn, auth socks5Auth) error {
 	if client == nil {
-		return
+		return nil
 	}
 	defer client.Close()
 
@@ -21,8 +21,7 @@ func handleClientRequest(client *net.TCPConn, auth socks5Auth) {
 	resp, err := proto.HandleHandshake(buff[0:n])
 	auth.EncodeWrite(client, resp) //加密
 	if err != nil {
-		log.Print(client.RemoteAddr(), err)
-		return
+		return err
 	}
 
 	//获取客户端代理的请求
@@ -31,8 +30,7 @@ func handleClientRequest(client *net.TCPConn, auth socks5Auth) {
 	resp, err = request.LSTRequest(buff[0:n])
 	auth.EncodeWrite(client, resp)
 	if err != nil {
-		log.Print(client.RemoteAddr(), err)
-		return
+		return err
 	}
 
 	log.Println(client.RemoteAddr(), request.DSTDOMAIN, request.DSTADDR, request.DSTPORT)
@@ -40,8 +38,7 @@ func handleClientRequest(client *net.TCPConn, auth socks5Auth) {
 	// 连接真正的远程服务
 	dstServer, err := net.DialTCP("tcp", nil, request.RAWADDR)
 	if err != nil {
-		log.Print(client.RemoteAddr(), err)
-		return
+		return err
 	}
 	defer dstServer.Close()
 
@@ -61,33 +58,39 @@ func handleClientRequest(client *net.TCPConn, auth socks5Auth) {
 	}()
 	wg.Wait()
 
+	return nil
 }
 
-func Server(listenAddrString string, encrytype string, passwd string) {
+func Server(listenAddrString string, encrytype string, passwd string) error {
 	//所有客户服务端的流都加密,
 	auth, err := CreateAuth(encrytype, passwd)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	// 监听客户端
 	listenAddr, err := net.ResolveTCPAddr("tcp", listenAddrString)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 	log.Printf("监听服务器端口: %s ", listenAddrString)
 
 	listener, err := net.ListenTCP("tcp", listenAddr)
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 	defer listener.Close()
 
 	for {
 		conn, err := listener.AcceptTCP()
 		if err != nil {
-			log.Fatal(err)
+			log.Print(err)
+			continue
 		}
-		go handleClientRequest(conn, auth)
+		go func(clientConn *net.TCPConn) {
+			if err := handleClientRequest(clientConn, auth); err != nil {
+				log.Print(clientConn.RemoteAddr(), err)
+			}
+		}(conn)
 	}
 }


### PR DESCRIPTION
## Summary
- make `Server` and `Client` return startup errors instead of exiting the process
- keep accept-loop errors recoverable by logging and continuing
- let `cmd/*/main.go` decide the process exit policy
- add focused tests for invalid startup addresses

## Verification
- `CGO_ENABLED=0 go test -run 'Test(ClientReturnsErrorOnInvalidServerAddress|ServerReturnsErrorOnInvalidListenAddress)$' .`
- `grep` for `log.Fatal` in the root package now only matches `cmd/*/main.go`

Closes #20