### PR TITLE
fix: preserve decode read errors in server handshake (#21)

### DIFF
--- a/server.go
+++ b/server.go
@@ -1,10 +1,41 @@
 package socks5proxy
 
 import (
+	"io"
 	"log"
 	"net"
 	"sync"
 )
+
+func handleHandshake(client io.ReadWriter, auth socks5Auth, buff []byte, proto *ProtocolVersion) error {
+	n, err := auth.DecodeRead(client, buff)
+	if err != nil {
+		return err
+	}
+
+	resp, err := proto.HandleHandshake(buff[:n])
+	if err != nil {
+		return err
+	}
+
+	_, err = auth.EncodeWrite(client, resp)
+	return err
+}
+
+func handleRequest(client io.ReadWriter, auth socks5Auth, buff []byte, request *Socks5Resolution) error {
+	n, err := auth.DecodeRead(client, buff)
+	if err != nil {
+		return err
+	}
+
+	resp, err := request.LSTRequest(buff[:n])
+	if err != nil {
+		return err
+	}
+
+	_, err = auth.EncodeWrite(client, resp)
+	return err
+}
 
 func handleClientRequest(client *net.TCPConn, auth socks5Auth) error {
 	if client == nil {
@@ -17,19 +48,13 @@ func handleClientRequest(client *net.TCPConn, auth socks5Auth) error {
 
 	// 认证协商
 	var proto ProtocolVersion
-	n, err := auth.DecodeRead(client, buff) //解密
-	resp, err := proto.HandleHandshake(buff[0:n])
-	auth.EncodeWrite(client, resp) //加密
-	if err != nil {
+	if err := handleHandshake(client, auth, buff, &proto); err != nil {
 		return err
 	}
 
 	//获取客户端代理的请求
 	var request Socks5Resolution
-	n, err = auth.DecodeRead(client, buff)
-	resp, err = request.LSTRequest(buff[0:n])
-	auth.EncodeWrite(client, resp)
-	if err != nil {
+	if err := handleRequest(client, auth, buff, &request); err != nil {
 		return err
 	}
 

--- a/server_test.go
+++ b/server_test.go
@@ -1,0 +1,81 @@
+package socks5proxy
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type stubAuth struct {
+	decodeReadFunc  func(io.ReadWriter, []byte) (int, error)
+	encodeWriteFunc func(io.ReadWriter, []byte) (int, error)
+}
+
+func (s stubAuth) Encrypt([]byte) error {
+	return nil
+}
+
+func (s stubAuth) Decrypt([]byte) error {
+	return nil
+}
+
+func (s stubAuth) EncodeWrite(rw io.ReadWriter, b []byte) (int, error) {
+	if s.encodeWriteFunc != nil {
+		return s.encodeWriteFunc(rw, b)
+	}
+	return len(b), nil
+}
+
+func (s stubAuth) DecodeRead(rw io.ReadWriter, b []byte) (int, error) {
+	if s.decodeReadFunc != nil {
+		return s.decodeReadFunc(rw, b)
+	}
+	return 0, nil
+}
+
+func TestHandleHandshakeReturnsDecodeReadError(t *testing.T) {
+	expectedErr := errors.New("decode read failed")
+	auth := stubAuth{
+		decodeReadFunc: func(io.ReadWriter, []byte) (int, error) {
+			return 0, expectedErr
+		},
+	}
+
+	err := handleHandshake(bytes.NewBuffer(nil), auth, make([]byte, 255), &ProtocolVersion{})
+
+	assert.Equal(t, expectedErr, err)
+}
+
+func TestHandleRequestReturnsDecodeReadError(t *testing.T) {
+	expectedErr := errors.New("decode read failed")
+	auth := stubAuth{
+		decodeReadFunc: func(io.ReadWriter, []byte) (int, error) {
+			return 0, expectedErr
+		},
+	}
+
+	err := handleRequest(bytes.NewBuffer(nil), auth, make([]byte, 255), &Socks5Resolution{})
+
+	assert.Equal(t, expectedErr, err)
+}
+
+func TestHandleHandshakeReturnsEncodeWriteError(t *testing.T) {
+	expectedErr := errors.New("encode write failed")
+	auth := stubAuth{
+		decodeReadFunc: func(_ io.ReadWriter, b []byte) (int, error) {
+			handshake := []byte{0x05, 0x01, 0x00}
+			copy(b, handshake)
+			return len(handshake), nil
+		},
+		encodeWriteFunc: func(io.ReadWriter, []byte) (int, error) {
+			return 0, expectedErr
+		},
+	}
+
+	err := handleHandshake(bytes.NewBuffer(nil), auth, make([]byte, 255), &ProtocolVersion{})
+
+	assert.Equal(t, expectedErr, err)
+}


### PR DESCRIPTION
## Summary
- split server handshake/request parsing into stepwise helpers
- return `DecodeRead`, parser, and `EncodeWrite` errors without overwriting them
- add focused tests for decode and encode error propagation

## Verification
- `CGO_ENABLED=0 go test -run 'TestHandleHandshakeReturnsDecodeReadError|TestHandleRequestReturnsDecodeReadError|TestHandleHandshakeReturnsEncodeWriteError' .`

Closes #21