### PR TITLE
fix: read SOCKS5 domain requests by exact lengths (#22)

### DIFF
--- a/server.go
+++ b/server.go
@@ -1,6 +1,7 @@
 package socks5proxy
 
 import (
+	"errors"
 	"io"
 	"log"
 	"net"
@@ -22,13 +23,52 @@ func handleHandshake(client io.ReadWriter, auth socks5Auth, buff []byte, proto *
 	return err
 }
 
-func handleRequest(client io.ReadWriter, auth socks5Auth, buff []byte, request *Socks5Resolution) error {
-	n, err := auth.DecodeRead(client, buff)
+func readEncryptedFull(reader io.Reader, auth socks5Auth, size int) ([]byte, error) {
+	buf := make([]byte, size)
+	_, err := io.ReadFull(reader, buf)
+	if err != nil {
+		return nil, err
+	}
+	if err := auth.Decrypt(buf); err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+func handleRequest(client io.ReadWriter, auth socks5Auth, request *Socks5Resolution) error {
+	header, err := readEncryptedFull(client, auth, 4)
 	if err != nil {
 		return err
 	}
 
-	resp, err := request.LSTRequest(buff[:n])
+	payload := append([]byte{}, header...)
+	var remaining int
+	switch header[3] {
+	case 1:
+		remaining = net.IPv4len + 2
+	case 3:
+		domainLenBytes, err := readEncryptedFull(client, auth, 1)
+		if err != nil {
+			return err
+		}
+		if domainLenBytes[0] == 0 {
+			return errors.New("域名长度错误")
+		}
+		payload = append(payload, domainLenBytes...)
+		remaining = int(domainLenBytes[0]) + 2
+	case 4:
+		remaining = net.IPv6len + 2
+	default:
+		return errors.New("IP地址错误")
+	}
+
+	tail, err := readEncryptedFull(client, auth, remaining)
+	if err != nil {
+		return err
+	}
+	payload = append(payload, tail...)
+
+	resp, err := request.LSTRequest(payload)
 	if err != nil {
 		return err
 	}
@@ -54,7 +94,7 @@ func handleClientRequest(client *net.TCPConn, auth socks5Auth) error {
 
 	//获取客户端代理的请求
 	var request Socks5Resolution
-	if err := handleRequest(client, auth, buff, &request); err != nil {
+	if err := handleRequest(client, auth, &request); err != nil {
 		return err
 	}
 

--- a/server_test.go
+++ b/server_test.go
@@ -14,6 +14,37 @@ type stubAuth struct {
 	encodeWriteFunc func(io.ReadWriter, []byte) (int, error)
 }
 
+type chunkedReadWriter struct {
+	chunks [][]byte
+	write  bytes.Buffer
+}
+
+func (c *chunkedReadWriter) Read(p []byte) (int, error) {
+	if len(c.chunks) == 0 {
+		return 0, io.EOF
+	}
+	chunk := c.chunks[0]
+	c.chunks = c.chunks[1:]
+	n := copy(p, chunk)
+	return n, nil
+}
+
+func (c *chunkedReadWriter) Write(p []byte) (int, error) {
+	return c.write.Write(p)
+}
+
+type failingReadWriter struct {
+	err error
+}
+
+func (f *failingReadWriter) Read([]byte) (int, error) {
+	return 0, f.err
+}
+
+func (f *failingReadWriter) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
 func (s stubAuth) Encrypt([]byte) error {
 	return nil
 }
@@ -26,7 +57,7 @@ func (s stubAuth) EncodeWrite(rw io.ReadWriter, b []byte) (int, error) {
 	if s.encodeWriteFunc != nil {
 		return s.encodeWriteFunc(rw, b)
 	}
-	return len(b), nil
+	return rw.Write(b)
 }
 
 func (s stubAuth) DecodeRead(rw io.ReadWriter, b []byte) (int, error) {
@@ -49,15 +80,12 @@ func TestHandleHandshakeReturnsDecodeReadError(t *testing.T) {
 	assert.Equal(t, expectedErr, err)
 }
 
-func TestHandleRequestReturnsDecodeReadError(t *testing.T) {
-	expectedErr := errors.New("decode read failed")
-	auth := stubAuth{
-		decodeReadFunc: func(io.ReadWriter, []byte) (int, error) {
-			return 0, expectedErr
-		},
-	}
+func TestHandleRequestReturnsReadError(t *testing.T) {
+	expectedErr := errors.New("read failed")
+	client := &failingReadWriter{err: expectedErr}
+	auth := stubAuth{}
 
-	err := handleRequest(bytes.NewBuffer(nil), auth, make([]byte, 255), &Socks5Resolution{})
+	err := handleRequest(client, auth, &Socks5Resolution{})
 
 	assert.Equal(t, expectedErr, err)
 }
@@ -78,4 +106,47 @@ func TestHandleHandshakeReturnsEncodeWriteError(t *testing.T) {
 	err := handleHandshake(bytes.NewBuffer(nil), auth, make([]byte, 255), &ProtocolVersion{})
 
 	assert.Equal(t, expectedErr, err)
+}
+
+func TestHandleRequestHandlesFragmentedDomainRequest(t *testing.T) {
+	requestBytes := []byte{
+		0x05, 0x01, 0x00, 0x03,
+		0x09,
+		'l', 'o', 'c', 'a', 'l', 'h', 'o', 's', 't',
+		0x00, 0x50,
+	}
+	client := &chunkedReadWriter{
+		chunks: [][]byte{
+			requestBytes[:2],
+			requestBytes[2:4],
+			requestBytes[4:5],
+			requestBytes[5:8],
+			requestBytes[8:12],
+			requestBytes[12:],
+		},
+	}
+	auth := stubAuth{}
+	request := &Socks5Resolution{}
+
+	err := handleRequest(client, auth, request)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "localhost", request.DSTDOMAIN)
+	assert.Equal(t, uint16(80), request.DSTPORT)
+	assert.Equal(t, []byte{0x05, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, client.write.Bytes())
+}
+
+func TestLSTRequestRejectsUnexpectedDomainLength(t *testing.T) {
+	request := &Socks5Resolution{}
+	packet := []byte{
+		0x05, 0x01, 0x00, 0x03,
+		0x03,
+		'a', 'b', 'c',
+		0x00, 0x50,
+		'z', 'z',
+	}
+
+	_, err := request.LSTRequest(packet)
+
+	assert.EqualError(t, err, "请求协议长度错误")
 }

--- a/socks5.go
+++ b/socks5.go
@@ -201,27 +201,48 @@ func (s *Socks5Resolution) LSTRequest(b []byte) ([]byte, error) {
 	s.RSV = b[2] //RSV保留字端，值长度为1个字节
 
 	s.ATYP = b[3]
+	addrEnd := 0
 
 	switch s.ATYP {
 	case 1:
 		//	IP V4 address: X'01'
+		if n != 4+net.IPv4len+2 {
+			return nil, errors.New("请求协议长度错误")
+		}
 		s.DSTADDR = b[4 : 4+net.IPv4len]
+		addrEnd = 4 + net.IPv4len
 	case 3:
 		//	DOMAINNAME: X'03'
-		s.DSTDOMAIN = string(b[5 : n-2])
+		if n < 5 {
+			return nil, errors.New("请求协议错误")
+		}
+		domainLen := int(b[4])
+		if domainLen == 0 {
+			return nil, errors.New("域名长度错误")
+		}
+		expectedLen := 4 + 1 + domainLen + 2
+		if n != expectedLen {
+			return nil, errors.New("请求协议长度错误")
+		}
+		s.DSTDOMAIN = string(b[5 : 5+domainLen])
 		ipAddr, err := net.ResolveIPAddr("ip", s.DSTDOMAIN)
 		if err != nil {
 			return nil, err
 		}
 		s.DSTADDR = ipAddr.IP
+		addrEnd = 5 + domainLen
 	case 4:
 		//	IP V6 address: X'04'
+		if n != 4+net.IPv6len+2 {
+			return nil, errors.New("请求协议长度错误")
+		}
 		s.DSTADDR = b[4 : 4+net.IPv6len]
+		addrEnd = 4 + net.IPv6len
 	default:
 		return nil, errors.New("IP地址错误")
 	}
 
-	s.DSTPORT = binary.BigEndian.Uint16(b[n-2 : n])
+	s.DSTPORT = binary.BigEndian.Uint16(b[addrEnd : addrEnd+2])
 	// DSTADDR全部换成IP地址，可以防止DNS污染和封杀
 	s.RAWADDR = &net.TCPAddr{
 		IP:   s.DSTADDR,


### PR DESCRIPTION
## Summary
- validate SOCKS5 request lengths strictly for IPv4, domain, and IPv6 targets
- parse domain names using the explicit length byte instead of `n-2`
- read the request in fixed segments on the server to handle TCP fragmentation cleanly
- add regression tests for fragmented domain requests and invalid length handling

## Verification
- `CGO_ENABLED=0 go test -run 'TestHandleHandshakeReturnsDecodeReadError|TestHandleRequestReturnsReadError|TestHandleHandshakeReturnsEncodeWriteError|TestHandleRequestHandlesFragmentedDomainRequest|TestLSTRequestRejectsUnexpectedDomainLength' .`

Closes #22