### PR TITLE
dx: normalize recv values and logging (#27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ cmd/client/main.go  `客户端主启动程`
         Input server listen address, for example: 16.158.6.16:18181
   -type string #设置流量混淆类型
     	Input traffic obfuscation type (simple/random, not secure encryption): (default "random")
+  -recv string #设置上游协议模式
+    	Upstream protocol mode: http or socks5 (default http)
 ```
 
 ## TODO

--- a/client.go
+++ b/client.go
@@ -135,7 +135,7 @@ func handleProxyRequest(localClient *net.TCPConn, serverAddr *net.TCPAddr, auth 
 		}()
 
 		wg.Wait()
-	} else {
+	} else if recvHTTPProto == "socks5" {
 		// 本地的内容copy到远程端
 		go func() {
 			defer wg.Done()
@@ -148,6 +148,8 @@ func handleProxyRequest(localClient *net.TCPConn, serverAddr *net.TCPAddr, auth 
 			SecureCopy(dstServer, localClient, auth.Decrypt)
 		}()
 		wg.Wait()
+	} else {
+		return errors.New("recv 参数仅支持 http 或 socks5")
 	}
 
 	return nil

--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -12,7 +12,7 @@ func main() {
 	serverAddr := flag.String("server", "", "Input server listen address:")
 	passwd := flag.String("passwd", "", "Input server proxy password:")
 	encrytype := flag.String("type", "random", "Input traffic obfuscation type (simple/random, not secure encryption):")
-	recvHTTPProto := flag.String("recv", "http", "use http or sock5 protocol(default http):")
+	recvHTTPProto := flag.String("recv", "http", "Upstream protocol mode: http or socks5 (default http):")
 	flag.Parse()
 	if *serverAddr == "" {
 		log.Fatal("请输入正确的远程地址")
@@ -21,7 +21,7 @@ func main() {
 		log.Fatal("请通过 -passwd 设置一个强密码（不能为空）")
 	}
 	log.Println("客户端正在启动...")
-	log.Println(&recvHTTPProto)
+	log.Println("recv proto:", *recvHTTPProto)
 	if err := socks5proxy.Client(*listenAddr, *serverAddr, *encrytype, *passwd, *recvHTTPProto); err != nil {
 		log.Fatal(err)
 	}

--- a/e2e_test.go
+++ b/e2e_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestConncet(t *testing.T) {
 	go Server("127.0.0.1:18189", "random", "abcedfg")
-	go Client("127.0.0.1:18190", "127.0.0.1:18189", "random", "abcedfg", "sock5")
+	go Client("127.0.0.1:18190", "127.0.0.1:18189", "random", "abcedfg", "socks5")
 
 	time.Sleep(1 * time.Second)
 


### PR DESCRIPTION
## Summary
- standardize `recv` values to `http` and `socks5`
- reject unsupported `recv` values instead of silently falling through
- log the actual `recv` mode instead of the flag pointer address
- align README and e2e usage with the same spelling

## Verification
- `CGO_ENABLED=0 go test ./...`

Closes #27