### PR TITLE
release: publish artifacts to GitHub Releases (#28)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,68 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      CGO_ENABLED: "0"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build release artifacts
+        run: |
+          mkdir -p dist
+          for os in linux windows; do
+            for component in client server; do
+              ext=""
+              if [ "$os" = "windows" ]; then
+                ext=".exe"
+              fi
+              GOOS="$os" GOARCH=amd64 go build \
+                -trimpath \
+                -ldflags="-s -w" \
+                -o "dist/socks5proxy_${component}_${os}_amd64${ext}" \
+                "./cmd/${component}"
+            done
+          done
+
+      - name: Generate SHA256 checksums
+        run: |
+          cd dist
+          sha256sum * > SHA256SUMS
+
+      - name: Install cosign
+        if: ${{ secrets.COSIGN_PRIVATE_KEY != '' }}
+        uses: sigstore/cosign-installer@v3
+
+      - name: Sign checksums
+        if: ${{ secrets.COSIGN_PRIVATE_KEY != '' }}
+        env:
+          COSIGN_PASSWORD: ${{ secrets.COSIGN_PASSWORD }}
+          COSIGN_PRIVATE_KEY: ${{ secrets.COSIGN_PRIVATE_KEY }}
+        run: |
+          cosign sign-blob \
+            --key env://COSIGN_PRIVATE_KEY \
+            --output-signature dist/SHA256SUMS.sig \
+            dist/SHA256SUMS
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/*

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,15 +1,25 @@
 # Release
 
-## V0.1版本
+发布物现在通过 GitHub Releases 提供，不再依赖外部网盘链接。
 
-### 说明
+## 发布方式
 
-1、添加了socks5的服务端和客户端功能
-2、添加了两种流量混淆模式：随机替换表和 Caesar 位移
+1. 推送形如 `v1.2.3` 的 Git tag。
+2. GitHub Actions `Release` workflow 会自动构建发布物并创建/更新对应 Release。
+3. Release 页面会附带以下产物：
+   - `socks5proxy_client_linux_amd64`
+   - `socks5proxy_server_linux_amd64`
+   - `socks5proxy_client_windows_amd64.exe`
+   - `socks5proxy_server_windows_amd64.exe`
+   - `SHA256SUMS`
+   - `SHA256SUMS.sig`（仅在仓库配置了 cosign 密钥时生成）
 
-### 下载
+## 校验方式
 
-- [vpn_client_linux_amd64_v0.1](https://pan.baidu.com/s/1r4ZEleOu4RgaSldkSfhHTQ)
-- [vpn_server_linux_amd64_v0.1](https://pan.baidu.com/s/1TAZmSqtRZME55q-ROGFsJQ)
-- [vpn_client_windows_amd64_v0.1](https://pan.baidu.com/s/1fJpAyLs9jjx23Q0itPrtzw)
-- [vpn_server_windows_amd64_v0.1](https://pan.baidu.com/s/1AGp-erpri3k0NkSrEGCoIQ)
+下载产物后，可使用 `SHA256SUMS` 验证完整性：
+
+```bash
+sha256sum -c SHA256SUMS
+```
+
+如果仓库配置了 cosign 签名材料，还会额外上传 `SHA256SUMS.sig` 作为可选签名校验文件。


### PR DESCRIPTION
## Summary
- add a tag-driven GitHub Actions release workflow
- build Linux/Windows amd64 client and server binaries for each release
- generate `SHA256SUMS` and optionally sign it when cosign secrets are configured
- replace stale external download links in `docs/release.md` with GitHub Releases guidance

## Verification
- `CGO_ENABLED=0 go test ./...`

Closes #28